### PR TITLE
use undefined to determine if an env var is set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export function getEnvVar(key, opts={}) {
   const fallback = process.env['NODE_ENV'] === 'development' ? opts.devDefault : undefined
-  let value = process.env[key] || fallback
+  let value = process.env[key] === undefined ? fallback : process.env[key]
 
   if(!opts.optional && typeof value === 'undefined')
     throw new Error(`${key} is undefined`)


### PR DESCRIPTION
This PR fixes an issue where falsy environment variables are returned as undefined
